### PR TITLE
Fix iframe cors errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name='robots' content='index, follow'>
   <meta charset='UTF-8'>
   <meta name='viewport' content='width=device-width, initial-scale=1'>
-  <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+  <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
   <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.8.3/dist/aframe-extras.min.js"></script>
 </head>
 

--- a/src/PersonalWebSpace_frontend/assets/defaultRoom.html
+++ b/src/PersonalWebSpace_frontend/assets/defaultRoom.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
     <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.8.3/dist/aframe-extras.min.js"></script>
     <script src="https://mannymeadows.github.io/Noosa/aframe-sun-sky.min.js"></script>
   </head>

--- a/src/PersonalWebSpace_frontend/assets/spacesUpperHtml.html
+++ b/src/PersonalWebSpace_frontend/assets/spacesUpperHtml.html
@@ -1,5 +1,5 @@
 <html>
   <head>
-    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
   </head>
   <body>

--- a/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
+++ b/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
@@ -8,7 +8,7 @@
   let glbModelPreviewString = getStringForSpaceFromModel(modelUrl);
 </script>
 <div class="glb-model-space-preview space-y-1">
-    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2" sandbox="allow-scripts" credentialless referrerpolicy="no-referrer"></iframe>
+    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe>
 </div>
 
 <style>

--- a/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
+++ b/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
@@ -8,7 +8,7 @@
   let glbModelPreviewString = getStringForSpaceFromModel(modelUrl);
 </script>
 <div class="glb-model-space-preview space-y-1">
-    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2"></iframe>
+    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2" credentialless></iframe>
 </div>
 
 <style>

--- a/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
+++ b/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
@@ -8,7 +8,7 @@
   let glbModelPreviewString = getStringForSpaceFromModel(modelUrl);
 </script>
 <div class="glb-model-space-preview space-y-1">
-    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
+    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2" sandbox="allow-scripts allow-same-origin"></iframe>
 </div>
 
 <style>

--- a/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
+++ b/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
@@ -8,7 +8,7 @@
   let glbModelPreviewString = getStringForSpaceFromModel(modelUrl);
 </script>
 <div class="glb-model-space-preview space-y-1">
-    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2" credentialless></iframe>
+    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2" credentialless referrerpolicy="no-referrer"></iframe>
 </div>
 
 <style>

--- a/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
+++ b/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
@@ -8,7 +8,7 @@
   let glbModelPreviewString = getStringForSpaceFromModel(modelUrl);
 </script>
 <div class="glb-model-space-preview space-y-1">
-    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2" sandbox="allow-scripts allow-same-origin"></iframe>
+    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2"></iframe>
 </div>
 
 <style>

--- a/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
+++ b/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
@@ -8,7 +8,7 @@
   let glbModelPreviewString = getStringForSpaceFromModel(modelUrl);
 </script>
 <div class="glb-model-space-preview space-y-1">
-    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe>
+    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
 </div>
 
 <style>

--- a/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
+++ b/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
@@ -46,7 +46,9 @@
 
 {#if entityHasValidUrl()}
   <div class="space-neighbor-preview space-y-1">
-    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" credentialless referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin"></iframe>
+    <a target="_blank" rel="noreferrer" href={entity.externalId} >
+      <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" credentialless referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin"></iframe>
+    </a>
     <button on:click={() => window.open(entity.externalId,'_blank')} class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">Visit Neighbor</button>
     {#if viewerIsSpaceOwner}
       {#if linkDeletionInProgress}

--- a/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
+++ b/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
@@ -46,7 +46,7 @@
 
 {#if entityHasValidUrl()}
   <div class="space-neighbor-preview space-y-1">
-    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
+    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" sandbox="allow-scripts allow-same-origin"></iframe>
     <button on:click={() => window.open(entity.externalId,'_blank')} class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">Visit Neighbor</button>
     {#if viewerIsSpaceOwner}
       {#if linkDeletionInProgress}

--- a/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
+++ b/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
@@ -46,7 +46,7 @@
 
 {#if entityHasValidUrl()}
   <div class="space-neighbor-preview space-y-1">
-    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" credentialless></iframe>
+    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" credentialless referrerpolicy="no-referrer"></iframe>
     <button on:click={() => window.open(entity.externalId,'_blank')} class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">Visit Neighbor</button>
     {#if viewerIsSpaceOwner}
       {#if linkDeletionInProgress}

--- a/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
+++ b/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
@@ -46,7 +46,7 @@
 
 {#if entityHasValidUrl()}
   <div class="space-neighbor-preview space-y-1">
-    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" sandbox="allow-scripts" credentialless referrerpolicy="no-referrer"></iframe>
+    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe>
     <button on:click={() => window.open(entity.externalId,'_blank')} class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">Visit Neighbor</button>
     {#if viewerIsSpaceOwner}
       {#if linkDeletionInProgress}

--- a/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
+++ b/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
@@ -46,7 +46,7 @@
 
 {#if entityHasValidUrl()}
   <div class="space-neighbor-preview space-y-1">
-    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" credentialless referrerpolicy="no-referrer"></iframe>
+    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" credentialless referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin"></iframe>
     <button on:click={() => window.open(entity.externalId,'_blank')} class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">Visit Neighbor</button>
     {#if viewerIsSpaceOwner}
       {#if linkDeletionInProgress}

--- a/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
+++ b/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
@@ -46,7 +46,7 @@
 
 {#if entityHasValidUrl()}
   <div class="space-neighbor-preview space-y-1">
-    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe>
+    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
     <button on:click={() => window.open(entity.externalId,'_blank')} class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">Visit Neighbor</button>
     {#if viewerIsSpaceOwner}
       {#if linkDeletionInProgress}

--- a/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
+++ b/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
@@ -46,7 +46,7 @@
 
 {#if entityHasValidUrl()}
   <div class="space-neighbor-preview space-y-1">
-    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto"></iframe>
+    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" credentialless></iframe>
     <button on:click={() => window.open(entity.externalId,'_blank')} class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">Visit Neighbor</button>
     {#if viewerIsSpaceOwner}
       {#if linkDeletionInProgress}

--- a/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
+++ b/src/PersonalWebSpace_frontend/components/ProtocolEntity.svelte
@@ -46,7 +46,7 @@
 
 {#if entityHasValidUrl()}
   <div class="space-neighbor-preview space-y-1">
-    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto" sandbox="allow-scripts allow-same-origin"></iframe>
+    <iframe src={entity.externalId} title="Entity Preview" width="100%" height="auto"></iframe>
     <button on:click={() => window.open(entity.externalId,'_blank')} class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">Visit Neighbor</button>
     {#if viewerIsSpaceOwner}
       {#if linkDeletionInProgress}

--- a/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
+++ b/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
@@ -255,7 +255,7 @@
                     />
                     {#if newNeighborUrl !== ""}
                         {#if neighborUrlInputHandler(newNeighborUrl)}
-                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" sandbox="allow-scripts" credentialless referrerpolicy="no-referrer"></iframe>
+                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe>
                             {#if neighborCreationInProgress}
                                 <img class="h-12 mx-auto" src={spinner} alt="loading animation" />
                             {:else}

--- a/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
+++ b/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
@@ -255,7 +255,9 @@
                     />
                     {#if newNeighborUrl !== ""}
                         {#if neighborUrlInputHandler(newNeighborUrl)}
-                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" credentialless referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin"></iframe>
+                            <a target="_blank" rel="noreferrer" href={newNeighborUrl} >
+                                <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" credentialless referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin"></iframe>
+                            </a>
                             {#if neighborCreationInProgress}
                                 <img class="h-12 mx-auto" src={spinner} alt="loading animation" />
                             {:else}

--- a/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
+++ b/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
@@ -255,7 +255,7 @@
                     />
                     {#if newNeighborUrl !== ""}
                         {#if neighborUrlInputHandler(newNeighborUrl)}
-                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" credentialless></iframe>
+                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" credentialless referrerpolicy="no-referrer"></iframe>
                             {#if neighborCreationInProgress}
                                 <img class="h-12 mx-auto" src={spinner} alt="loading animation" />
                             {:else}

--- a/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
+++ b/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
@@ -255,7 +255,7 @@
                     />
                     {#if newNeighborUrl !== ""}
                         {#if neighborUrlInputHandler(newNeighborUrl)}
-                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" credentialless referrerpolicy="no-referrer"></iframe>
+                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" credentialless referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin"></iframe>
                             {#if neighborCreationInProgress}
                                 <img class="h-12 mx-auto" src={spinner} alt="loading animation" />
                             {:else}

--- a/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
+++ b/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
@@ -255,7 +255,7 @@
                     />
                     {#if newNeighborUrl !== ""}
                         {#if neighborUrlInputHandler(newNeighborUrl)}
-                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" sandbox="allow-scripts allow-same-origin"></iframe>
+                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2"></iframe>
                             {#if neighborCreationInProgress}
                                 <img class="h-12 mx-auto" src={spinner} alt="loading animation" />
                             {:else}

--- a/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
+++ b/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
@@ -255,7 +255,7 @@
                     />
                     {#if newNeighborUrl !== ""}
                         {#if neighborUrlInputHandler(newNeighborUrl)}
-                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2"></iframe>
+                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" credentialless></iframe>
                             {#if neighborCreationInProgress}
                                 <img class="h-12 mx-auto" src={spinner} alt="loading animation" />
                             {:else}

--- a/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
+++ b/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
@@ -255,7 +255,7 @@
                     />
                     {#if newNeighborUrl !== ""}
                         {#if neighborUrlInputHandler(newNeighborUrl)}
-                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe>
+                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
                             {#if neighborCreationInProgress}
                                 <img class="h-12 mx-auto" src={spinner} alt="loading animation" />
                             {:else}

--- a/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
+++ b/src/PersonalWebSpace_frontend/components/SpaceNeighbors.svelte
@@ -255,7 +255,7 @@
                     />
                     {#if newNeighborUrl !== ""}
                         {#if neighborUrlInputHandler(newNeighborUrl)}
-                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
+                            <iframe src={newNeighborUrl} title="Preview of the new Neighbor" width="100%" height="auto" class="py-2" sandbox="allow-scripts allow-same-origin"></iframe>
                             {#if neighborCreationInProgress}
                                 <img class="h-12 mx-auto" src={spinner} alt="loading animation" />
                             {:else}

--- a/src/PersonalWebSpace_frontend/components/UserSpace.svelte
+++ b/src/PersonalWebSpace_frontend/components/UserSpace.svelte
@@ -105,7 +105,7 @@
 <div class="responsive">
   <div class="space space-y-1"> 
     <a target="_blank" rel="noreferrer" href={spaceURL} >
-      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe>
+      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
     </a>
     {#if isViewerSpaceOwner() && entityIdToLinkTo !== ""}
       {#if linkCreationInProgress}

--- a/src/PersonalWebSpace_frontend/components/UserSpace.svelte
+++ b/src/PersonalWebSpace_frontend/components/UserSpace.svelte
@@ -105,7 +105,7 @@
 <div class="responsive">
   <div class="space space-y-1"> 
     <a target="_blank" rel="noreferrer" href={spaceURL} >
-      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto" credentialless></iframe>
+      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto" credentialless referrerpolicy="no-referrer"></iframe>
     </a>
     {#if isViewerSpaceOwner() && entityIdToLinkTo !== ""}
       {#if linkCreationInProgress}

--- a/src/PersonalWebSpace_frontend/components/UserSpace.svelte
+++ b/src/PersonalWebSpace_frontend/components/UserSpace.svelte
@@ -105,7 +105,7 @@
 <div class="responsive">
   <div class="space space-y-1"> 
     <a target="_blank" rel="noreferrer" href={spaceURL} >
-      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto" sandbox="allow-scripts" credentialless referrerpolicy="no-referrer"></iframe>
+      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe>
     </a>
     {#if isViewerSpaceOwner() && entityIdToLinkTo !== ""}
       {#if linkCreationInProgress}

--- a/src/PersonalWebSpace_frontend/components/UserSpace.svelte
+++ b/src/PersonalWebSpace_frontend/components/UserSpace.svelte
@@ -105,7 +105,7 @@
 <div class="responsive">
   <div class="space space-y-1"> 
     <a target="_blank" rel="noreferrer" href={spaceURL} >
-      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto"></iframe>
+      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto" credentialless></iframe>
     </a>
     {#if isViewerSpaceOwner() && entityIdToLinkTo !== ""}
       {#if linkCreationInProgress}

--- a/src/PersonalWebSpace_frontend/components/UserSpace.svelte
+++ b/src/PersonalWebSpace_frontend/components/UserSpace.svelte
@@ -105,7 +105,7 @@
 <div class="responsive">
   <div class="space space-y-1"> 
     <a target="_blank" rel="noreferrer" href={spaceURL} >
-      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
+      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto" sandbox="allow-scripts allow-same-origin"></iframe>
     </a>
     {#if isViewerSpaceOwner() && entityIdToLinkTo !== ""}
       {#if linkCreationInProgress}

--- a/src/PersonalWebSpace_frontend/components/UserSpace.svelte
+++ b/src/PersonalWebSpace_frontend/components/UserSpace.svelte
@@ -105,7 +105,7 @@
 <div class="responsive">
   <div class="space space-y-1"> 
     <a target="_blank" rel="noreferrer" href={spaceURL} >
-      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto" sandbox="allow-scripts allow-same-origin"></iframe>
+      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto"></iframe>
     </a>
     {#if isViewerSpaceOwner() && entityIdToLinkTo !== ""}
       {#if linkCreationInProgress}

--- a/src/PersonalWebSpace_frontend/helpers/space_helpers.js
+++ b/src/PersonalWebSpace_frontend/helpers/space_helpers.js
@@ -7,7 +7,7 @@ export const formatUserSpaces = (userSpaces) => {
     const space = userSpaces[i];
     userSpacesString += `<div class='responsive' width="100%" height="auto"> <div class='space'> `;
     const spaceURL = `https://${PersonalWebSpace_frontend_canister_id}.raw.ic0.app/#/space/${space.id}`;
-    userSpacesString += `<a target='_blank' href="${spaceURL}" > <iframe src="${spaceURL}" alt='Your flaming hot Personal Web Space' width="100%" height="auto" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe> </a> `;
+    userSpacesString += `<a target='_blank' href="${spaceURL}" > <iframe src="${spaceURL}" alt='Your flaming hot Personal Web Space' width="100%" height="auto" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe> </a> `;
     userSpacesString += `<button onclick="window.open('${spaceURL}','_blank')" class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">View</button> `;
     userSpacesString += `<button type='button' class="space-details-collapsible bg-slate-500 text-white py-2 px-4 rounded font-semibold">See Details</button>`;
     // show space details

--- a/src/PersonalWebSpace_frontend/helpers/space_helpers.js
+++ b/src/PersonalWebSpace_frontend/helpers/space_helpers.js
@@ -7,7 +7,7 @@ export const formatUserSpaces = (userSpaces) => {
     const space = userSpaces[i];
     userSpacesString += `<div class='responsive' width="100%" height="auto"> <div class='space'> `;
     const spaceURL = `https://${PersonalWebSpace_frontend_canister_id}.raw.ic0.app/#/space/${space.id}`;
-    userSpacesString += `<a target='_blank' href="${spaceURL}" > <iframe src="${spaceURL}" alt='Your flaming hot Personal Web Space' width="100%" height="auto" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe> </a> `;
+    userSpacesString += `<a target='_blank' href="${spaceURL}" > <iframe src="${spaceURL}" alt='Your flaming hot Personal Web Space' width="100%" height="auto" sandbox="allow-scripts allow-same-origin"></iframe> </a> `;
     userSpacesString += `<button onclick="window.open('${spaceURL}','_blank')" class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">View</button> `;
     userSpacesString += `<button type='button' class="space-details-collapsible bg-slate-500 text-white py-2 px-4 rounded font-semibold">See Details</button>`;
     // show space details

--- a/src/PersonalWebSpace_frontend/helpers/space_helpers.js
+++ b/src/PersonalWebSpace_frontend/helpers/space_helpers.js
@@ -7,7 +7,7 @@ export const formatUserSpaces = (userSpaces) => {
     const space = userSpaces[i];
     userSpacesString += `<div class='responsive' width="100%" height="auto"> <div class='space'> `;
     const spaceURL = `https://${PersonalWebSpace_frontend_canister_id}.raw.ic0.app/#/space/${space.id}`;
-    userSpacesString += `<a target='_blank' href="${spaceURL}" > <iframe src="${spaceURL}" alt='Your flaming hot Personal Web Space' width="100%" height="auto" sandbox="allow-scripts allow-same-origin"></iframe> </a> `;
+    userSpacesString += `<a target='_blank' href="${spaceURL}" > <iframe src="${spaceURL}" alt='Your flaming hot Personal Web Space' width="100%" height="auto"></iframe> </a> `;
     userSpacesString += `<button onclick="window.open('${spaceURL}','_blank')" class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">View</button> `;
     userSpacesString += `<button type='button' class="space-details-collapsible bg-slate-500 text-white py-2 px-4 rounded font-semibold">See Details</button>`;
     // show space details

--- a/src/PersonalWebSpace_frontend/helpers/space_helpers.js
+++ b/src/PersonalWebSpace_frontend/helpers/space_helpers.js
@@ -65,7 +65,7 @@ export const initiateCollapsibles = () => {
 
 export const getStringForSpaceFromModel = (modelUrl) => {
   return `<html>
-    <head><script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script></head>
+    <head><script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script></head>
     <body>
       <a-scene cursor="rayOrigin: mouse" gltf-model="dracoDecoderPath: https://www.gstatic.com/draco/v1/decoders/;">
         <a-assets>

--- a/src/PersonalWebSpace_frontend/helpers/space_helpers.js
+++ b/src/PersonalWebSpace_frontend/helpers/space_helpers.js
@@ -7,7 +7,7 @@ export const formatUserSpaces = (userSpaces) => {
     const space = userSpaces[i];
     userSpacesString += `<div class='responsive' width="100%" height="auto"> <div class='space'> `;
     const spaceURL = `https://${PersonalWebSpace_frontend_canister_id}.raw.ic0.app/#/space/${space.id}`;
-    userSpacesString += `<a target='_blank' href="${spaceURL}" > <iframe src="${spaceURL}" alt='Your flaming hot Personal Web Space' width="100%" height="auto" sandbox="allow-scripts" credentialless referrerpolicy="no-referrer"></iframe> </a> `;
+    userSpacesString += `<a target='_blank' href="${spaceURL}" > <iframe src="${spaceURL}" alt='Your flaming hot Personal Web Space' width="100%" height="auto" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe> </a> `;
     userSpacesString += `<button onclick="window.open('${spaceURL}','_blank')" class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">View</button> `;
     userSpacesString += `<button type='button' class="space-details-collapsible bg-slate-500 text-white py-2 px-4 rounded font-semibold">See Details</button>`;
     // show space details

--- a/src/PersonalWebSpace_frontend/pages/CreateSpace.svelte
+++ b/src/PersonalWebSpace_frontend/pages/CreateSpace.svelte
@@ -87,7 +87,7 @@
   <h3 class="text-xl font-semibold">Spaces Ready For You:</h3>
   <!-- Default Space 1 -->
   <h3 class="text-l font-semibold">The Web3 Cockpit</h3>
-  <iframe src="#/defaultspace/1" title="The Web3 Cockpit" width="100%" height="auto" sandbox="allow-scripts allow-same-origin"></iframe>
+  <iframe src="#/defaultspace/1" title="The Web3 Cockpit" width="100%" height="auto"></iframe>
   {#if !$store.isAuthed}
     <button type='button' id='createButton' disabled class="bg-slate-500 text-white font-bold py-2 px-4 rounded opacity-50 cursor-not-allowed">Create This Space!</button>
     <p id='createSubtextDefault1'>{loginSubtext}</p>

--- a/src/PersonalWebSpace_frontend/pages/CreateSpace.svelte
+++ b/src/PersonalWebSpace_frontend/pages/CreateSpace.svelte
@@ -87,7 +87,7 @@
   <h3 class="text-xl font-semibold">Spaces Ready For You:</h3>
   <!-- Default Space 1 -->
   <h3 class="text-l font-semibold">The Web3 Cockpit</h3>
-  <iframe src="#/defaultspace/1" title="The Web3 Cockpit" width="100%" height="auto" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe>
+  <iframe src="#/defaultspace/1" title="The Web3 Cockpit" width="100%" height="auto" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
   {#if !$store.isAuthed}
     <button type='button' id='createButton' disabled class="bg-slate-500 text-white font-bold py-2 px-4 rounded opacity-50 cursor-not-allowed">Create This Space!</button>
     <p id='createSubtextDefault1'>{loginSubtext}</p>

--- a/src/PersonalWebSpace_frontend/pages/CreateSpace.svelte
+++ b/src/PersonalWebSpace_frontend/pages/CreateSpace.svelte
@@ -87,7 +87,7 @@
   <h3 class="text-xl font-semibold">Spaces Ready For You:</h3>
   <!-- Default Space 1 -->
   <h3 class="text-l font-semibold">The Web3 Cockpit</h3>
-  <iframe src="#/defaultspace/1" title="The Web3 Cockpit" width="100%" height="auto" sandbox="allow-scripts" credentialless referrerpolicy="no-referrer"></iframe>
+  <iframe src="#/defaultspace/1" title="The Web3 Cockpit" width="100%" height="auto" sandbox="allow-scripts" referrerpolicy="no-referrer"></iframe>
   {#if !$store.isAuthed}
     <button type='button' id='createButton' disabled class="bg-slate-500 text-white font-bold py-2 px-4 rounded opacity-50 cursor-not-allowed">Create This Space!</button>
     <p id='createSubtextDefault1'>{loginSubtext}</p>

--- a/src/PersonalWebSpace_frontend/pages/CreateSpace.svelte
+++ b/src/PersonalWebSpace_frontend/pages/CreateSpace.svelte
@@ -87,7 +87,7 @@
   <h3 class="text-xl font-semibold">Spaces Ready For You:</h3>
   <!-- Default Space 1 -->
   <h3 class="text-l font-semibold">The Web3 Cockpit</h3>
-  <iframe src="#/defaultspace/1" title="The Web3 Cockpit" width="100%" height="auto"></iframe>
+  <iframe src="#/defaultspace/1" title="The Web3 Cockpit" width="100%" height="auto" credentialless></iframe>
   {#if !$store.isAuthed}
     <button type='button' id='createButton' disabled class="bg-slate-500 text-white font-bold py-2 px-4 rounded opacity-50 cursor-not-allowed">Create This Space!</button>
     <p id='createSubtextDefault1'>{loginSubtext}</p>

--- a/src/PersonalWebSpace_frontend/pages/CreateSpace.svelte
+++ b/src/PersonalWebSpace_frontend/pages/CreateSpace.svelte
@@ -87,7 +87,7 @@
   <h3 class="text-xl font-semibold">Spaces Ready For You:</h3>
   <!-- Default Space 1 -->
   <h3 class="text-l font-semibold">The Web3 Cockpit</h3>
-  <iframe src="#/defaultspace/1" title="The Web3 Cockpit" width="100%" height="auto" credentialless></iframe>
+  <iframe src="#/defaultspace/1" title="The Web3 Cockpit" width="100%" height="auto" referrerpolicy="no-referrer"></iframe>
   {#if !$store.isAuthed}
     <button type='button' id='createButton' disabled class="bg-slate-500 text-white font-bold py-2 px-4 rounded opacity-50 cursor-not-allowed">Create This Space!</button>
     <p id='createSubtextDefault1'>{loginSubtext}</p>

--- a/src/PersonalWebSpace_frontend/pages/CreateSpace.svelte
+++ b/src/PersonalWebSpace_frontend/pages/CreateSpace.svelte
@@ -87,7 +87,7 @@
   <h3 class="text-xl font-semibold">Spaces Ready For You:</h3>
   <!-- Default Space 1 -->
   <h3 class="text-l font-semibold">The Web3 Cockpit</h3>
-  <iframe src="#/defaultspace/1" title="The Web3 Cockpit" width="100%" height="auto" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
+  <iframe src="#/defaultspace/1" title="The Web3 Cockpit" width="100%" height="auto" sandbox="allow-scripts allow-same-origin"></iframe>
   {#if !$store.isAuthed}
     <button type='button' id='createButton' disabled class="bg-slate-500 text-white font-bold py-2 px-4 rounded opacity-50 cursor-not-allowed">Create This Space!</button>
     <p id='createSubtextDefault1'>{loginSubtext}</p>


### PR DESCRIPTION
Includes changes to iframe security and upgrades A-Frame to version 1.4.2

To test:
iframe: 
All iframes should display normally
under My Spaces
on Create page
on Explore page
Space's Neighbors and new Neighbor preview

Known issue: Neighbor iframes get credentials passed through (even though iframes on other pages don't)

A-Frame Upgrade:
Complete app should behave as expected