### PR TITLE
Create space from uploaded model

### DIFF
--- a/NotesOnLocalDev.md
+++ b/NotesOnLocalDev.md
@@ -59,7 +59,7 @@ Go to OIM's codebase (where the file you're reading is in)
 Start a local replica in this project (OIM)
 Deploy this project's canisters, PersonalWebSpace_backend and PersonalWebSpace_frontend, see deploy command in README (after these steps the following canister ids should be assigned: PersonalWebSpace_backend canister id: rrkah-fqaaa-aaaaa-aaaaq-cai; PersonalWebSpace_frontend canister id: ryjl3-tyaaa-aaaaa-aaaba-cai)
 Go to the folder with Bebb Protocol's latest version and run dfx deploy there (this creates the local Bebb Protocol canister on the local replica started earlier which is thus the same replica this project's canisters are running on)
-Make sure the local canister id for the deployed Bebb Protocol canister is rkp4c-7iaaa-aaaaa-aaaca-cai (required by this project to make the calls on the local replica)
+Make sure the local canister id for the deployed Bebb Protocol canister is br5f7-7uaaa-aaaaa-qaaca-cai (required by this project to make the calls on the local replica)
 This project's canisters should now successfully call the locally deployed Bebb Protocol canister (i.e. all functionality works, same as on mainnet)
 Test via npm run vite
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ dfx deploy --argument "(
     symbol = \"PWS\";
     maxLimit = 65535;
   }
-)"
+)" PersonalWebSpace_backend
+dfx deploy
 
 --> access frontend at http://localhost:4943/?canisterId=ryjl3-tyaaa-aaaaa-aaaba-cai
 access routes like so http://localhost:4943/?canisterId=ryjl3-tyaaa-aaaaa-aaaba-cai#/testroom

--- a/dfx.json
+++ b/dfx.json
@@ -12,7 +12,7 @@
         "candid": "src/integrations/BebbProtocol/newwave.did",
         "id": {
           "ic": "pzrof-pyaaa-aaaai-acnha-cai",
-          "local": "rkp4c-7iaaa-aaaaa-aaaca-cai"
+          "local": "br5f7-7uaaa-aaaaa-qaaca-cai"
         }
       }
     },

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <meta charset='UTF-8'>
   <meta name='viewport' content='width=device-width, initial-scale=1'>
   <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
-  <script src="//cdn.rawgit.com/donmccurdy/aframe-extras/v3.8.3/dist/aframe-extras.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.0.0/dist/aframe-extras.min.js"></script>
 </head>
 
 <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@dfinity/agent": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.1.tgz",
-      "integrity": "sha512-Lu/TXdDj3XJgMNZYVdrECyo+zqlOxDR1I1mA7OuO6lsIciildJNbqDnsMQAit7605S4B8QLnvbnK/Okd8c2K1g==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.6.tgz",
+      "integrity": "sha512-Ch+tXAszPap0zwRgr/oFEgJLDld4RDwBdFDqR1JUg38xhHWTFMrTkjMT6uQFvqf6d2wDXnh3zwhqbg5P7OCv7A==",
       "requires": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -26,9 +26,9 @@
       }
     },
     "@dfinity/auth-client": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.15.3.tgz",
-      "integrity": "sha512-yM+0v1zKvPWVbOR1akvDcEMfHIvCSa7dII6jXrD/EW+VEcH7LhcWJIUIqz4vQw/QXXTB/CNKa6k7jvjr1XdXbw==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.15.6.tgz",
+      "integrity": "sha512-UpqJ2qab8IlijUiXR0ig4Ww4ymXzE6auSXHf8fXcLSIT8NTAD/7U8+VLUcPj8rkqrExcNMCskeipKxnqHINJYw==",
       "requires": {
         "idb": "^7.0.2"
       }
@@ -42,9 +42,9 @@
       }
     },
     "@dfinity/candid": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.1.tgz",
-      "integrity": "sha512-vmMjyfXfMO16X9c4ivKoGS/fNYue2+t55LTmCL0Tv5Nn81LC9Bn2IuPdXcguoRQSXISJzTS59epL3E20ELL+dA==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.6.tgz",
+      "integrity": "sha512-Q9PGvhTE/1dTLfSo0pu0+ifzA7NA4X1rgSy9TE6O1Glk6Kl8Nf+Pg2sCHS2hWt0RAiKfR2glEVlbUAm6S8vRxA==",
       "requires": {
         "ts-node": "^10.8.2"
       }
@@ -60,9 +60,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.1.tgz",
-      "integrity": "sha512-IYODveUhLx6CikhpT+KPuzwNi/czypOlgFj+Jtp+yHb6odUxfg0V/qVwZ4UbQPictNJ1gl7WwGjJeF5ybf+e6w==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.6.tgz",
+      "integrity": "sha512-eMsS5YofRk5Hm6LlhzyBvw1RzDxM5FWPtepQuYeZbZyD/ztq4TrUiScqoKBFw/LLODd0znt8rGnNgqtt+7JnQA==",
       "requires": {
         "js-sha256": "^0.9.0",
         "ts-node": "^10.8.2"
@@ -303,9 +303,9 @@
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "@tsconfig/svelte": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "stop": "dfx stop"
   },
   "dependencies": {
-    "@dfinity/agent": "0.15.1",
-    "@dfinity/auth-client": "^0.15.1",
+    "@dfinity/agent": "0.15.6",
+    "@dfinity/auth-client": "^0.15.6",
     "@dfinity/authentication": "^0.14.2",
-    "@dfinity/candid": "0.15.1",
-    "@dfinity/principal": "0.15.1",
+    "@dfinity/candid": "0.15.6",
+    "@dfinity/principal": "0.15.6",
     "svelte-spa-router": "^3.3.0",
     "three": "^0.148.0"
   },

--- a/src/PersonalWebSpace_backend/Protocol.mo
+++ b/src/PersonalWebSpace_backend/Protocol.mo
@@ -2,7 +2,7 @@ import Text "mo:base/Text";
 // from https://github.com/patnorris/NewWavePre/tree/firstMotokoVersion/NewWaveV0/0.0.3
 module {
     public let CANISTER_ID : Text = "pzrof-pyaaa-aaaai-acnha-cai";
-    public let LOCAL_CANISTER_ID : Text = "rkp4c-7iaaa-aaaaa-aaaca-cai";
+    public let LOCAL_CANISTER_ID : Text = "by6od-j4aaa-aaaaa-qaadq-cai";
     
     public class EntitySettings() {
         var mainSetting : Text = "default";

--- a/src/PersonalWebSpace_backend/main.mo
+++ b/src/PersonalWebSpace_backend/main.mo
@@ -597,6 +597,47 @@ shared actor class PersonalWebSpace(custodian: Principal, init : Types.Dip721Non
           return(response);
         };
       };
+    } else if (Text.contains(request.url, #text("/file/"))) {
+      if (Text.contains(request.url, #text("fileId"))) {
+        var fileId = Iter.toArray(Text.tokens(request.url, #text("fileId=")))[1];
+        if (Text.contains(fileId, #text("canisterId"))) {
+          // for local retrievals during development
+          fileId := Iter.toArray(Text.tokens(fileId, #text("?canisterId")))[0];
+        };
+        let item = fileDatabase.get(fileId);
+        switch (item) {
+          case (null) {
+            let response = {
+              body = Text.encodeUtf8("Invalid fileId " # fileId);
+              headers = [];
+              status_code = 404 : Nat16;
+              streaming_strategy = null;
+              upgrade = false;
+            };
+            return(response);
+          };
+          case (?file) {
+            let body = file.file_content;
+            let response = {
+              body = body;
+              headers = [("Content-Type", "application/gltf-buffer"), ("Content-Length", Nat.toText(body.size())), ("Access-Control-Allow-Origin", "*"), ("X-Frame-Options", "ALLOWALL")];
+              status_code = 200 : Nat16;
+              streaming_strategy = null;
+              upgrade = false;
+            };
+            return(response);
+          };
+        };        
+      } else {
+        let response = {
+          body = Text.encodeUtf8("Not implemented");
+          headers = [];
+          status_code = 404 : Nat16;
+          streaming_strategy = null;
+          upgrade = false;
+        };
+        return(response);
+      };
     } else {
       return {
         upgrade = false; // ← If this is set to true, the request will be sent to http_request_update()
@@ -817,7 +858,7 @@ public shared(msg) func uploadUserFile(fileName : Text, content : FileTypes.File
   let newUserRecord = {file_ids = newFilesId; totalSize = userTotalSize + fileSize };
   userFileRecords.put(Principal.toText(user), newUserRecord);
 
-  return #Ok(#Success);
+  return #Ok(#FileId(newFileId));
 };
 
 /*
@@ -846,7 +887,7 @@ public shared(msg) func listUserFileIds() : async FileTypes.FileResult {
  *
  * @return The file info associated with the file id
 */
-public shared(msg) func getFile(fileId: Text) : async FileTypes.FileResult {
+public query func getFile(fileId: Text) : async FileTypes.FileResult {
   let retrievedFile = fileDatabase.get(fileId);
   switch (retrievedFile)
   {
@@ -924,8 +965,7 @@ public shared(msg) func deleteFile(fileId: Text) : async FileTypes.FileResult {
   };
 
 
-
-  // Upgrade Hooks
+// Upgrade Hooks
   system func preupgrade() {
     fileDatabaseStable := Iter.toArray(fileDatabase.entries());
     userFileRecordsStable := Iter.toArray(userFileRecords.entries());

--- a/src/PersonalWebSpace_frontend/assets/.ic-assets.json
+++ b/src/PersonalWebSpace_frontend/assets/.ic-assets.json
@@ -1,0 +1,23 @@
+[
+  {
+    "match": "**/*",
+    "allow_raw_access": true,
+    "headers": {
+      "Access-Control-Allow-Origin": "*",
+      "X-Frame-Options": "ALLOWALL"
+    },
+    "ignore": false
+  },
+  {
+    "match": ".well-known",
+    "ignore": false
+  },
+  {
+    "match": ".well-known/ii-alternative-origins",
+    "headers": {
+      "Access-Control-Allow-Origin": "*",
+      "Content-Type": "application/json"
+    },
+    "ignore": false
+  }
+]

--- a/src/PersonalWebSpace_frontend/assets/.well-known/ii-alternative-origins
+++ b/src/PersonalWebSpace_frontend/assets/.well-known/ii-alternative-origins
@@ -1,0 +1,3 @@
+{
+  "alternativeOrigins": ["https://vdfyi-uaaaa-aaaai-acptq-cai.icp0.io"]
+}

--- a/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
+++ b/src/PersonalWebSpace_frontend/components/GlbModelPreview.svelte
@@ -1,14 +1,17 @@
 <script>
-  import { getStringForSpaceFromModel } from "../helpers/space_helpers";
+  import { getStringForSpaceFromModel, getStringForSpaceFromUserUploadedModel } from "../helpers/space_helpers";
 
   export let modelUrl;
+  export let modelType;
   modelUrl = modelUrl;
 
 // Note: HTML as string in Svelte needs the ending script tag to be escaped (see https://github.com/sveltejs/svelte/issues/5810)
-  let glbModelPreviewString = getStringForSpaceFromModel(modelUrl);
+  let glbModelPreviewString = modelType === "WebHosted" 
+    ? getStringForSpaceFromModel(modelUrl)
+    : getStringForSpaceFromUserUploadedModel();
 </script>
 <div class="glb-model-space-preview space-y-1">
-    <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2" credentialless referrerpolicy="no-referrer"></iframe>
+  <iframe srcdoc={glbModelPreviewString} title="Preview of the Glb Model" width="100%" height="auto" class="py-2"></iframe>
 </div>
 
 <style>

--- a/src/PersonalWebSpace_frontend/helpers/space_helpers.js
+++ b/src/PersonalWebSpace_frontend/helpers/space_helpers.js
@@ -65,9 +65,11 @@ export const initiateCollapsibles = () => {
 
 export const getStringForSpaceFromModel = (modelUrl) => {
   return `<html>
-    <head><script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script></head>
+    <head>
+      <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
+    </head>
     <body>
-      <a-scene cursor="rayOrigin: mouse" gltf-model="dracoDecoderPath: https://www.gstatic.com/draco/v1/decoders/;">
+      <a-scene id="aSceneForModelPreview" cursor="rayOrigin: mouse" gltf-model="dracoDecoderPath: https://www.gstatic.com/draco/v1/decoders/;">
         <a-assets>
           <a-asset-item id="model-glb" src=${modelUrl} crossorigin="anonymous"></a-asset-item>
           <img crossorigin="anonymous" id="groundTexture" src="https://cdn.aframe.io/a-painter/images/floor.jpg">
@@ -81,6 +83,28 @@ export const getStringForSpaceFromModel = (modelUrl) => {
         <a-sky color="#ECECEC"></a-sky>
 
         <a-entity gltf-model="#model-glb" position="0 0 -5"></a-entity>
+      </a-scene>
+    </body>
+  </html>`;
+};
+
+export const getStringForSpaceFromUserUploadedModel = () => {
+  return `<html>
+    <head>
+      <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
+    </head>
+    <body>
+      <a-scene id="aSceneForModelPreview" cursor="rayOrigin: mouse" gltf-model="dracoDecoderPath: https://www.gstatic.com/draco/v1/decoders/;">
+        <a-assets>
+          <img crossorigin="anonymous" id="groundTexture" src="https://cdn.aframe.io/a-painter/images/floor.jpg">
+          <img crossorigin="anonymous" id="skyTexture" src="https://cdn.aframe.io/a-painter/images/sky.jpg">
+        </a-assets>
+
+        <a-light type="directional" intensity="0.9" position="-1 -2  2"></a-light>
+        <a-light type="directional" intensity="1.0" position=" 2  1 -1"></a-light>
+
+        <a-plane src="#groundTexture" rotation="-90 0 0" position="0 -0.01 0" height="100" width="100"></a-plane>
+        <a-sky color="#ECECEC"></a-sky>
       </a-scene>
     </body>
   </html>`;

--- a/src/PersonalWebSpace_frontend/pages/Space.svelte
+++ b/src/PersonalWebSpace_frontend/pages/Space.svelte
@@ -16,8 +16,6 @@
   import { getEntityClipboardRepresentation } from '../helpers/entity.js';
   import { extractSpaceMetadata } from '../helpers/space_helpers.js';
 
-  import { PersonalWebSpace_backend } from "canisters/PersonalWebSpace_backend";
-
 // This is needed for URL params
   export let params;
 

--- a/src/declarations/PersonalWebSpace_backend/PersonalWebSpace_backend.did
+++ b/src/declarations/PersonalWebSpace_backend/PersonalWebSpace_backend.did
@@ -59,7 +59,7 @@ type PersonalWebSpace =
    createSpace: (text) -> (NftResult);
    deleteFile: (text) -> (FileResult);
    getCallerSpaces: () -> (vec Nft) query;
-   getFile: (text) -> (FileResult);
+   getFile: (text) -> (FileResult) query;
    getMaxLimitDip721: () -> (nat16) query;
    getMetadataDip721: (TokenId) -> (MetadataResult) query;
    getMetadataForUserDip721: (principal) -> (ExtendedMetadataResult);

--- a/src/declarations/PersonalWebSpace_backend/PersonalWebSpace_backend.did.d.ts
+++ b/src/declarations/PersonalWebSpace_backend/PersonalWebSpace_backend.did.d.ts
@@ -16,10 +16,10 @@ export type ExtendedMetadataResult = {
     'Ok' : { 'token_id' : TokenId, 'metadata_desc' : MetadataDesc }
   } |
   { 'Err' : ApiError };
-export type File = Uint8Array;
+export type File = Uint8Array | number[];
 export interface FileInfo {
   'file_name' : string,
-  'file_content' : Uint8Array,
+  'file_content' : Uint8Array | number[],
   'owner_principal' : string,
 }
 export type FileResult = { 'Ok' : FileResultSuccessOptions } |
@@ -42,7 +42,7 @@ export interface LogoResult { 'data' : string, 'logo_type' : string }
 export type MetadataDesc = Array<MetadataPart>;
 export interface MetadataKeyVal { 'key' : string, 'val' : MetadataVal }
 export interface MetadataPart {
-  'data' : Uint8Array,
+  'data' : Uint8Array | number[],
   'key_val_data' : Array<MetadataKeyVal>,
   'purpose' : MetadataPurpose,
 }
@@ -56,7 +56,7 @@ export type MetadataVal = { 'Nat64Content' : bigint } |
   { 'NatContent' : bigint } |
   { 'Nat16Content' : number } |
   { 'TextArrayContent' : Array<string> } |
-  { 'BlobContent' : Uint8Array } |
+  { 'BlobContent' : Uint8Array | number[] } |
   { 'PrincipalContent' : Principal } |
   { 'TextToTextAssocListContent' : AssocList } |
   { 'TextContent' : string };
@@ -84,7 +84,10 @@ export interface PersonalWebSpace {
   'getMetadataForUserDip721' : ActorMethod<[Principal], ExtendedMetadataResult>,
   'getRandomSpace' : ActorMethod<[], NftResult>,
   'getSpace' : ActorMethod<[TokenId], NftResult>,
-  'getTokenIdsForUserDip721' : ActorMethod<[Principal], BigUint64Array>,
+  'getTokenIdsForUserDip721' : ActorMethod<
+    [Principal],
+    BigUint64Array | bigint[]
+  >,
   'getUserRecord' : ActorMethod<[], FileResult>,
   'greet' : ActorMethod<[string], string>,
   'http_request' : ActorMethod<[Request], Response>,
@@ -111,11 +114,11 @@ export interface PersonalWebSpace {
 export interface Request {
   'url' : string,
   'method' : string,
-  'body' : Uint8Array,
+  'body' : Uint8Array | number[],
   'headers' : Array<HeaderField>,
 }
 export interface Response {
-  'body' : Uint8Array,
+  'body' : Uint8Array | number[],
   'headers' : Array<HeaderField>,
   'upgrade' : boolean,
   'streaming_strategy' : [] | [StreamingStrategy],
@@ -127,7 +130,7 @@ export type StreamingCallback = ActorMethod<
 >;
 export interface StreamingCallbackResponse {
   'token' : [] | [StreamingCallbackToken],
-  'body' : Uint8Array,
+  'body' : Uint8Array | number[],
 }
 export interface StreamingCallbackToken {
   'key' : string,

--- a/src/declarations/PersonalWebSpace_backend/PersonalWebSpace_backend.did.js
+++ b/src/declarations/PersonalWebSpace_backend/PersonalWebSpace_backend.did.js
@@ -132,7 +132,7 @@ export const idlFactory = ({ IDL }) => {
     'createSpace' : IDL.Func([IDL.Text], [NftResult], []),
     'deleteFile' : IDL.Func([IDL.Text], [FileResult], []),
     'getCallerSpaces' : IDL.Func([], [IDL.Vec(Nft)], ['query']),
-    'getFile' : IDL.Func([IDL.Text], [FileResult], []),
+    'getFile' : IDL.Func([IDL.Text], [FileResult], ['query']),
     'getMaxLimitDip721' : IDL.Func([], [IDL.Nat16], ['query']),
     'getMetadataDip721' : IDL.Func([TokenId], [MetadataResult], ['query']),
     'getMetadataForUserDip721' : IDL.Func(

--- a/src/declarations/PersonalWebSpace_backend/index.js
+++ b/src/declarations/PersonalWebSpace_backend/index.js
@@ -4,8 +4,14 @@ import { Actor, HttpAgent } from "@dfinity/agent";
 import { idlFactory } from "./PersonalWebSpace_backend.did.js";
 export { idlFactory } from "./PersonalWebSpace_backend.did.js";
 
-// CANISTER_ID is replaced by webpack based on node environment
-export const canisterId = process.env.PERSONALWEBSPACE_BACKEND_CANISTER_ID;
+/* CANISTER_ID is replaced by webpack based on node environment
+ * Note: canister environment variable will be standardized as
+ * process.env.CANISTER_ID_<CANISTER_NAME_UPPERCASE>
+ * beginning in dfx 0.15.0
+ */
+export const canisterId =
+  process.env.CANISTER_ID_PERSONALWEBSPACE_BACKEND ||
+  process.env.PERSONALWEBSPACE_BACKEND_CANISTER_ID;
 
 export const createActor = (canisterId, options = {}) => {
   const agent = options.agent || new HttpAgent({ ...options.agentOptions });

--- a/src/declarations/PersonalWebSpace_frontend/PersonalWebSpace_frontend.did
+++ b/src/declarations/PersonalWebSpace_frontend/PersonalWebSpace_frontend.did
@@ -8,6 +8,8 @@ type CreateAssetArguments = record {
   content_type: text;
   max_age: opt nat64;
   headers: opt vec HeaderField;
+  enable_aliasing: opt bool;
+  allow_raw_access: opt bool;
 };
 
 // Add or change content for an asset, by content encoding
@@ -36,10 +38,31 @@ type BatchOperationKind = variant {
   CreateAsset: CreateAssetArguments;
   SetAssetContent: SetAssetContentArguments;
 
+  SetAssetProperties: SetAssetPropertiesArguments;
+
   UnsetAssetContent: UnsetAssetContentArguments;
   DeleteAsset: DeleteAssetArguments;
 
   Clear: ClearArguments;
+};
+
+type CommitBatchArguments = record {
+  batch_id: BatchId;
+  operations: vec BatchOperationKind
+};
+
+type CommitProposedBatchArguments = record {
+  batch_id: BatchId;
+  evidence: blob;
+};
+
+type ComputeEvidenceArguments = record {
+  batch_id: BatchId;
+  max_iterations: opt nat16
+};
+
+type DeleteBatchArguments = record {
+  batch_id: BatchId;
 };
 
 type HeaderField = record { text; text; };
@@ -49,6 +72,7 @@ type HttpRequest = record {
   url: text;
   headers: vec HeaderField;
   body: blob;
+  certificate_version: opt nat16;
 };
 
 type HttpResponse = record {
@@ -77,7 +101,34 @@ type StreamingStrategy = variant {
   };
 };
 
+type SetAssetPropertiesArguments = record {
+  key: Key;
+  max_age: opt opt nat64;
+  headers: opt opt vec HeaderField;
+  allow_raw_access: opt opt bool;
+  is_aliased: opt opt bool;
+};
+
+type Permission = variant {
+  Commit;
+  ManagePermissions;
+  Prepare;
+};
+
+type GrantPermission = record {
+  to_principal: principal;
+  permission: Permission;
+};
+type RevokePermission = record {
+  of_principal: principal;
+  permission: Permission;
+};
+type ListPermitted = record { permission: Permission };
+
+type ValidationResult = variant { Ok : text; Err : text };
+
 service: {
+  api_version: () -> (nat16) query;
 
   get: (record {
     key: Key;
@@ -120,7 +171,19 @@ service: {
   create_chunk: (record { batch_id: BatchId; content: blob }) -> (record { chunk_id: ChunkId });
 
   // Perform all operations successfully, or reject
-  commit_batch: (record { batch_id: BatchId; operations: vec BatchOperationKind }) -> ();
+  commit_batch: (CommitBatchArguments) -> ();
+
+  // Save the batch operations for later commit
+  propose_commit_batch: (CommitBatchArguments) -> ();
+
+  // Given a batch already proposed, perform all operations successfully, or reject
+  commit_proposed_batch: (CommitProposedBatchArguments) -> ();
+
+  // Compute a hash over the CommitBatchArguments.  Call until it returns Some(evidence).
+  compute_evidence: (ComputeEvidenceArguments) -> (opt blob);
+
+  // Delete a batch that has been created, or proposed for commit, but not yet committed
+  delete_batch: (DeleteBatchArguments) -> ();
 
   create_asset: (CreateAssetArguments) -> ();
   set_asset_content: (SetAssetContentArguments) -> ();
@@ -144,4 +207,22 @@ service: {
   http_request_streaming_callback: (token: StreamingCallbackToken) -> (opt StreamingCallbackHttpResponse) query;
 
   authorize: (principal) -> ();
+  deauthorize: (principal) -> ();
+  list_authorized: () -> (vec principal) query;
+  grant_permission: (GrantPermission) -> ();
+  revoke_permission: (RevokePermission) -> ();
+  list_permitted: (ListPermitted) -> (vec principal) query;
+  take_ownership: () -> ();
+
+  get_asset_properties : (key: Key) -> (record {
+    max_age: opt nat64;
+    headers: opt vec HeaderField;
+    allow_raw_access: opt bool;
+    is_aliased: opt bool; } ) query;
+  set_asset_properties: (SetAssetPropertiesArguments) -> ();
+
+  validate_grant_permission: (GrantPermission) -> (ValidationResult);
+  validate_revoke_permission: (RevokePermission) -> (ValidationResult);
+  validate_take_ownership: () -> (ValidationResult);
+  validate_commit_proposed_batch: (CommitProposedBatchArguments) -> (ValidationResult);
 }

--- a/src/declarations/PersonalWebSpace_frontend/PersonalWebSpace_frontend.did.d.ts
+++ b/src/declarations/PersonalWebSpace_frontend/PersonalWebSpace_frontend.did.d.ts
@@ -2,47 +2,85 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 
 export type BatchId = bigint;
-export type BatchOperationKind = { 'CreateAsset' : CreateAssetArguments } |
+export type BatchOperationKind = {
+    'SetAssetProperties' : SetAssetPropertiesArguments
+  } |
+  { 'CreateAsset' : CreateAssetArguments } |
   { 'UnsetAssetContent' : UnsetAssetContentArguments } |
   { 'DeleteAsset' : DeleteAssetArguments } |
   { 'SetAssetContent' : SetAssetContentArguments } |
   { 'Clear' : ClearArguments };
 export type ChunkId = bigint;
 export type ClearArguments = {};
+export interface CommitBatchArguments {
+  'batch_id' : BatchId,
+  'operations' : Array<BatchOperationKind>,
+}
+export interface CommitProposedBatchArguments {
+  'batch_id' : BatchId,
+  'evidence' : Uint8Array | number[],
+}
+export interface ComputeEvidenceArguments {
+  'batch_id' : BatchId,
+  'max_iterations' : [] | [number],
+}
 export interface CreateAssetArguments {
   'key' : Key,
   'content_type' : string,
   'headers' : [] | [Array<HeaderField>],
+  'allow_raw_access' : [] | [boolean],
   'max_age' : [] | [bigint],
+  'enable_aliasing' : [] | [boolean],
 }
 export interface DeleteAssetArguments { 'key' : Key }
+export interface DeleteBatchArguments { 'batch_id' : BatchId }
+export interface GrantPermission {
+  'permission' : Permission,
+  'to_principal' : Principal,
+}
 export type HeaderField = [string, string];
 export interface HttpRequest {
   'url' : string,
   'method' : string,
-  'body' : Uint8Array,
+  'body' : Uint8Array | number[],
   'headers' : Array<HeaderField>,
+  'certificate_version' : [] | [number],
 }
 export interface HttpResponse {
-  'body' : Uint8Array,
+  'body' : Uint8Array | number[],
   'headers' : Array<HeaderField>,
   'streaming_strategy' : [] | [StreamingStrategy],
   'status_code' : number,
 }
 export type Key = string;
+export interface ListPermitted { 'permission' : Permission }
+export type Permission = { 'Prepare' : null } |
+  { 'ManagePermissions' : null } |
+  { 'Commit' : null };
+export interface RevokePermission {
+  'permission' : Permission,
+  'of_principal' : Principal,
+}
 export interface SetAssetContentArguments {
   'key' : Key,
-  'sha256' : [] | [Uint8Array],
+  'sha256' : [] | [Uint8Array | number[]],
   'chunk_ids' : Array<ChunkId>,
   'content_encoding' : string,
 }
+export interface SetAssetPropertiesArguments {
+  'key' : Key,
+  'headers' : [] | [[] | [Array<HeaderField>]],
+  'is_aliased' : [] | [[] | [boolean]],
+  'allow_raw_access' : [] | [[] | [boolean]],
+  'max_age' : [] | [[] | [bigint]],
+}
 export interface StreamingCallbackHttpResponse {
   'token' : [] | [StreamingCallbackToken],
-  'body' : Uint8Array,
+  'body' : Uint8Array | number[],
 }
 export interface StreamingCallbackToken {
   'key' : Key,
-  'sha256' : [] | [Uint8Array],
+  'sha256' : [] | [Uint8Array | number[]],
   'index' : bigint,
   'content_encoding' : string,
 }
@@ -57,45 +95,65 @@ export interface UnsetAssetContentArguments {
   'key' : Key,
   'content_encoding' : string,
 }
+export type ValidationResult = { 'Ok' : string } |
+  { 'Err' : string };
 export interface _SERVICE {
+  'api_version' : ActorMethod<[], number>,
   'authorize' : ActorMethod<[Principal], undefined>,
   'certified_tree' : ActorMethod<
     [{}],
-    { 'certificate' : Uint8Array, 'tree' : Uint8Array }
+    { 'certificate' : Uint8Array | number[], 'tree' : Uint8Array | number[] }
   >,
   'clear' : ActorMethod<[ClearArguments], undefined>,
-  'commit_batch' : ActorMethod<
-    [{ 'batch_id' : BatchId, 'operations' : Array<BatchOperationKind> }],
+  'commit_batch' : ActorMethod<[CommitBatchArguments], undefined>,
+  'commit_proposed_batch' : ActorMethod<
+    [CommitProposedBatchArguments],
     undefined
+  >,
+  'compute_evidence' : ActorMethod<
+    [ComputeEvidenceArguments],
+    [] | [Uint8Array | number[]]
   >,
   'create_asset' : ActorMethod<[CreateAssetArguments], undefined>,
   'create_batch' : ActorMethod<[{}], { 'batch_id' : BatchId }>,
   'create_chunk' : ActorMethod<
-    [{ 'content' : Uint8Array, 'batch_id' : BatchId }],
+    [{ 'content' : Uint8Array | number[], 'batch_id' : BatchId }],
     { 'chunk_id' : ChunkId }
   >,
+  'deauthorize' : ActorMethod<[Principal], undefined>,
   'delete_asset' : ActorMethod<[DeleteAssetArguments], undefined>,
+  'delete_batch' : ActorMethod<[DeleteBatchArguments], undefined>,
   'get' : ActorMethod<
     [{ 'key' : Key, 'accept_encodings' : Array<string> }],
     {
-      'content' : Uint8Array,
-      'sha256' : [] | [Uint8Array],
+      'content' : Uint8Array | number[],
+      'sha256' : [] | [Uint8Array | number[]],
       'content_type' : string,
       'content_encoding' : string,
       'total_length' : bigint,
+    }
+  >,
+  'get_asset_properties' : ActorMethod<
+    [Key],
+    {
+      'headers' : [] | [Array<HeaderField>],
+      'is_aliased' : [] | [boolean],
+      'allow_raw_access' : [] | [boolean],
+      'max_age' : [] | [bigint],
     }
   >,
   'get_chunk' : ActorMethod<
     [
       {
         'key' : Key,
-        'sha256' : [] | [Uint8Array],
+        'sha256' : [] | [Uint8Array | number[]],
         'index' : bigint,
         'content_encoding' : string,
       },
     ],
-    { 'content' : Uint8Array }
+    { 'content' : Uint8Array | number[] }
   >,
+  'grant_permission' : ActorMethod<[GrantPermission], undefined>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
   'http_request_streaming_callback' : ActorMethod<
     [StreamingCallbackToken],
@@ -109,7 +167,7 @@ export interface _SERVICE {
         'encodings' : Array<
           {
             'modified' : Time,
-            'sha256' : [] | [Uint8Array],
+            'sha256' : [] | [Uint8Array | number[]],
             'length' : bigint,
             'content_encoding' : string,
           }
@@ -118,18 +176,40 @@ export interface _SERVICE {
       }
     >
   >,
+  'list_authorized' : ActorMethod<[], Array<Principal>>,
+  'list_permitted' : ActorMethod<[ListPermitted], Array<Principal>>,
+  'propose_commit_batch' : ActorMethod<[CommitBatchArguments], undefined>,
+  'revoke_permission' : ActorMethod<[RevokePermission], undefined>,
   'set_asset_content' : ActorMethod<[SetAssetContentArguments], undefined>,
+  'set_asset_properties' : ActorMethod<
+    [SetAssetPropertiesArguments],
+    undefined
+  >,
   'store' : ActorMethod<
     [
       {
         'key' : Key,
-        'content' : Uint8Array,
-        'sha256' : [] | [Uint8Array],
+        'content' : Uint8Array | number[],
+        'sha256' : [] | [Uint8Array | number[]],
         'content_type' : string,
         'content_encoding' : string,
       },
     ],
     undefined
   >,
+  'take_ownership' : ActorMethod<[], undefined>,
   'unset_asset_content' : ActorMethod<[UnsetAssetContentArguments], undefined>,
+  'validate_commit_proposed_batch' : ActorMethod<
+    [CommitProposedBatchArguments],
+    ValidationResult
+  >,
+  'validate_grant_permission' : ActorMethod<
+    [GrantPermission],
+    ValidationResult
+  >,
+  'validate_revoke_permission' : ActorMethod<
+    [RevokePermission],
+    ValidationResult
+  >,
+  'validate_take_ownership' : ActorMethod<[], ValidationResult>,
 }

--- a/src/declarations/PersonalWebSpace_frontend/PersonalWebSpace_frontend.did.js
+++ b/src/declarations/PersonalWebSpace_frontend/PersonalWebSpace_frontend.did.js
@@ -3,11 +3,20 @@ export const idlFactory = ({ IDL }) => {
   const BatchId = IDL.Nat;
   const Key = IDL.Text;
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
+  const SetAssetPropertiesArguments = IDL.Record({
+    'key' : Key,
+    'headers' : IDL.Opt(IDL.Opt(IDL.Vec(HeaderField))),
+    'is_aliased' : IDL.Opt(IDL.Opt(IDL.Bool)),
+    'allow_raw_access' : IDL.Opt(IDL.Opt(IDL.Bool)),
+    'max_age' : IDL.Opt(IDL.Opt(IDL.Nat64)),
+  });
   const CreateAssetArguments = IDL.Record({
     'key' : Key,
     'content_type' : IDL.Text,
     'headers' : IDL.Opt(IDL.Vec(HeaderField)),
+    'allow_raw_access' : IDL.Opt(IDL.Bool),
     'max_age' : IDL.Opt(IDL.Nat64),
+    'enable_aliasing' : IDL.Opt(IDL.Bool),
   });
   const UnsetAssetContentArguments = IDL.Record({
     'key' : Key,
@@ -22,17 +31,41 @@ export const idlFactory = ({ IDL }) => {
     'content_encoding' : IDL.Text,
   });
   const BatchOperationKind = IDL.Variant({
+    'SetAssetProperties' : SetAssetPropertiesArguments,
     'CreateAsset' : CreateAssetArguments,
     'UnsetAssetContent' : UnsetAssetContentArguments,
     'DeleteAsset' : DeleteAssetArguments,
     'SetAssetContent' : SetAssetContentArguments,
     'Clear' : ClearArguments,
   });
+  const CommitBatchArguments = IDL.Record({
+    'batch_id' : BatchId,
+    'operations' : IDL.Vec(BatchOperationKind),
+  });
+  const CommitProposedBatchArguments = IDL.Record({
+    'batch_id' : BatchId,
+    'evidence' : IDL.Vec(IDL.Nat8),
+  });
+  const ComputeEvidenceArguments = IDL.Record({
+    'batch_id' : BatchId,
+    'max_iterations' : IDL.Opt(IDL.Nat16),
+  });
+  const DeleteBatchArguments = IDL.Record({ 'batch_id' : BatchId });
+  const Permission = IDL.Variant({
+    'Prepare' : IDL.Null,
+    'ManagePermissions' : IDL.Null,
+    'Commit' : IDL.Null,
+  });
+  const GrantPermission = IDL.Record({
+    'permission' : Permission,
+    'to_principal' : IDL.Principal,
+  });
   const HttpRequest = IDL.Record({
     'url' : IDL.Text,
     'method' : IDL.Text,
     'body' : IDL.Vec(IDL.Nat8),
     'headers' : IDL.Vec(HeaderField),
+    'certificate_version' : IDL.Opt(IDL.Nat16),
   });
   const StreamingCallbackToken = IDL.Record({
     'key' : Key,
@@ -61,7 +94,14 @@ export const idlFactory = ({ IDL }) => {
     'status_code' : IDL.Nat16,
   });
   const Time = IDL.Int;
+  const ListPermitted = IDL.Record({ 'permission' : Permission });
+  const RevokePermission = IDL.Record({
+    'permission' : Permission,
+    'of_principal' : IDL.Principal,
+  });
+  const ValidationResult = IDL.Variant({ 'Ok' : IDL.Text, 'Err' : IDL.Text });
   return IDL.Service({
+    'api_version' : IDL.Func([], [IDL.Nat16], ['query']),
     'authorize' : IDL.Func([IDL.Principal], [], []),
     'certified_tree' : IDL.Func(
         [IDL.Record({})],
@@ -74,14 +114,11 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'clear' : IDL.Func([ClearArguments], [], []),
-    'commit_batch' : IDL.Func(
-        [
-          IDL.Record({
-            'batch_id' : BatchId,
-            'operations' : IDL.Vec(BatchOperationKind),
-          }),
-        ],
-        [],
+    'commit_batch' : IDL.Func([CommitBatchArguments], [], []),
+    'commit_proposed_batch' : IDL.Func([CommitProposedBatchArguments], [], []),
+    'compute_evidence' : IDL.Func(
+        [ComputeEvidenceArguments],
+        [IDL.Opt(IDL.Vec(IDL.Nat8))],
         [],
       ),
     'create_asset' : IDL.Func([CreateAssetArguments], [], []),
@@ -95,7 +132,9 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Record({ 'chunk_id' : ChunkId })],
         [],
       ),
+    'deauthorize' : IDL.Func([IDL.Principal], [], []),
     'delete_asset' : IDL.Func([DeleteAssetArguments], [], []),
+    'delete_batch' : IDL.Func([DeleteBatchArguments], [], []),
     'get' : IDL.Func(
         [IDL.Record({ 'key' : Key, 'accept_encodings' : IDL.Vec(IDL.Text) })],
         [
@@ -105,6 +144,18 @@ export const idlFactory = ({ IDL }) => {
             'content_type' : IDL.Text,
             'content_encoding' : IDL.Text,
             'total_length' : IDL.Nat,
+          }),
+        ],
+        ['query'],
+      ),
+    'get_asset_properties' : IDL.Func(
+        [Key],
+        [
+          IDL.Record({
+            'headers' : IDL.Opt(IDL.Vec(HeaderField)),
+            'is_aliased' : IDL.Opt(IDL.Bool),
+            'allow_raw_access' : IDL.Opt(IDL.Bool),
+            'max_age' : IDL.Opt(IDL.Nat64),
           }),
         ],
         ['query'],
@@ -121,6 +172,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Record({ 'content' : IDL.Vec(IDL.Nat8) })],
         ['query'],
       ),
+    'grant_permission' : IDL.Func([GrantPermission], [], []),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
     'http_request_streaming_callback' : IDL.Func(
         [StreamingCallbackToken],
@@ -147,7 +199,16 @@ export const idlFactory = ({ IDL }) => {
         ],
         ['query'],
       ),
+    'list_authorized' : IDL.Func([], [IDL.Vec(IDL.Principal)], ['query']),
+    'list_permitted' : IDL.Func(
+        [ListPermitted],
+        [IDL.Vec(IDL.Principal)],
+        ['query'],
+      ),
+    'propose_commit_batch' : IDL.Func([CommitBatchArguments], [], []),
+    'revoke_permission' : IDL.Func([RevokePermission], [], []),
     'set_asset_content' : IDL.Func([SetAssetContentArguments], [], []),
+    'set_asset_properties' : IDL.Func([SetAssetPropertiesArguments], [], []),
     'store' : IDL.Func(
         [
           IDL.Record({
@@ -161,7 +222,24 @@ export const idlFactory = ({ IDL }) => {
         [],
         [],
       ),
+    'take_ownership' : IDL.Func([], [], []),
     'unset_asset_content' : IDL.Func([UnsetAssetContentArguments], [], []),
+    'validate_commit_proposed_batch' : IDL.Func(
+        [CommitProposedBatchArguments],
+        [ValidationResult],
+        [],
+      ),
+    'validate_grant_permission' : IDL.Func(
+        [GrantPermission],
+        [ValidationResult],
+        [],
+      ),
+    'validate_revoke_permission' : IDL.Func(
+        [RevokePermission],
+        [ValidationResult],
+        [],
+      ),
+    'validate_take_ownership' : IDL.Func([], [ValidationResult], []),
   });
 };
 export const init = ({ IDL }) => { return []; };

--- a/src/declarations/PersonalWebSpace_frontend/index.js
+++ b/src/declarations/PersonalWebSpace_frontend/index.js
@@ -4,8 +4,14 @@ import { Actor, HttpAgent } from "@dfinity/agent";
 import { idlFactory } from "./PersonalWebSpace_frontend.did.js";
 export { idlFactory } from "./PersonalWebSpace_frontend.did.js";
 
-// CANISTER_ID is replaced by webpack based on node environment
-export const canisterId = process.env.PERSONALWEBSPACE_FRONTEND_CANISTER_ID;
+/* CANISTER_ID is replaced by webpack based on node environment
+ * Note: canister environment variable will be standardized as
+ * process.env.CANISTER_ID_<CANISTER_NAME_UPPERCASE>
+ * beginning in dfx 0.15.0
+ */
+export const canisterId =
+  process.env.CANISTER_ID_PERSONALWEBSPACE_FRONTEND ||
+  process.env.PERSONALWEBSPACE_FRONTEND_CANISTER_ID;
 
 export const createActor = (canisterId, options = {}) => {
   const agent = options.agent || new HttpAgent({ ...options.agentOptions });

--- a/src/integrations/BebbProtocol/index.js
+++ b/src/integrations/BebbProtocol/index.js
@@ -6,7 +6,7 @@ import { idlFactory } from "./newwave.did.js";
 export { idlFactory } from "./newwave.did.js";
 
 // CANISTER_ID is put manually
-export const canisterId = process.env.NODE_ENV !== "development" ? "pzrof-pyaaa-aaaai-acnha-cai" : "rkp4c-7iaaa-aaaaa-aaaca-cai";
+export const canisterId = process.env.NODE_ENV !== "development" ? "pzrof-pyaaa-aaaai-acnha-cai" : "by6od-j4aaa-aaaaa-qaadq-cai";
 
 export const createActor = (canisterId, options = {}) => {
   const agent = options.agent || new HttpAgent({ ...options.agentOptions });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -88,14 +88,14 @@ export default defineConfig({
       allow: ["."],
     },
     //__________Local vs Mainnet Development____________
-    /* proxy: {
+    proxy: {
       // This proxies all http requests made to /api to our running dfx instance
       "/api": {
         target: `http://127.0.0.1:4943`,
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, "/api"),
       },
-    }, */
+    },
   },
   define: {
     // Here we can define global constants

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,11 +31,17 @@ const aliases = Object.entries(dfxJson.canisters || {}).reduce(
   (acc, [name, _value]) => {
     // Get the network name, or `local` by default.
     const networkName = process.env["DFX_NETWORK"] || "local";
-    const outputRoot = path.join(
+    /* const outputRoot = path.join(
       __dirname,
       ".dfx",
       networkName,
       "canisters",
+      name,
+    ); */
+    const outputRoot = path.join(
+      __dirname,
+      "src",
+      "declarations",
       name,
     );
 
@@ -97,6 +103,9 @@ export default defineConfig({
     ...canisterDefinitions,
     "process.env.NODE_ENV": JSON.stringify(
       isDev ? "development" : "production",
+    ),
+    "process.env.DFX_NETWORK": JSON.stringify(
+      isDev ? "local" : "ic",
     ),
     global: process.env.NODE_ENV === "development" ? "globalThis" : "global",
   },


### PR DESCRIPTION
Adds a new section on the Create space view; users can now select a glb file from their device, see the model in a preview scene and then create a new space with the model file to be included (as seen in the preview).

Open: When loading the new space, the uploaded model file currently isn't loaded (via its URL, which hits the backend canister's HTTP file to return the file).

To test:
Make sure the local setup still works (see below)
go to the Create tab on the page and scroll to the upload model section
select a file
preview the scene with the model
confirm the space creation
see the confirmation that the space was created
see the new space under My Spaces
load the new space
the space should look like the preview (including the uploaded model) [see Open; this currently doesn't work as the model isn't being loaded via its URL]

Local setup changes:
this PR also includes changes to the local setup in response to upgrading dfx to the latest version
the local Bebb Protocol canister is receiving a different canister id now (which seems stable and is updated as part of the PR)
you might not need to upgrade dfx to run and test this 