### PR TITLE
Add link button to Inspector toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <script src="https://mannymeadows.github.io/Noosa/aframe-sun-sky.min.js"></script>
   <script type="module" src="src/PersonalWebSpace_frontend/helpers/webportal.js"></script>
   <script type="module" src="src/PersonalWebSpace_frontend/helpers/video-play-on-click.js"></script>
+  <script type="module" src="src/PersonalWebSpace_frontend/helpers/new-tab-link.js"></script>
 </head>
 
 <body>

--- a/src/PersonalWebSpace_frontend/helpers/new-tab-link.js
+++ b/src/PersonalWebSpace_frontend/helpers/new-tab-link.js
@@ -1,0 +1,14 @@
+export const component = AFRAME.registerComponent('new-tab-link', {
+  schema: {
+    href: { default: 'https://aframe.io' },
+  },
+
+  init: function() {
+    this.el.addEventListener('click', (e) => {
+      if (!document.body.classList.contains('aframe-inspector-opened')) {
+        // Only open if Inspector isn't opened.
+        window.open(this.data.href, '_blank');
+      };
+    })
+  },
+});

--- a/src/PersonalWebSpace_frontend/pages/Space.svelte
+++ b/src/PersonalWebSpace_frontend/pages/Space.svelte
@@ -243,6 +243,53 @@
     };
   };
 
+  const addLinkButtonToToolbar = (toolbar) => {
+    // Create a new anchor element
+    const newButton = document.createElement("a");
+    // Add required properties to the anchor element
+    newButton.title = "link";
+    newButton.className = "button fa fa-external-link";
+    // Add click event listener to the new button
+    newButton.addEventListener("click", function() {
+      // Remove 'active' class from other toolbar buttons
+      const toolbarButtons = toolbar.querySelectorAll(".button");
+      toolbarButtons.forEach(button => button.classList.remove("active"));
+      // Add 'active' class to this button
+      newButton.classList.add("active");
+      // @ts-ignore
+      if (AFRAME.INSPECTOR.selectedEntity) {
+        // Show a popup for URL input
+        const url = prompt("Enter the URL to link the selected item. The link will be displayed when the item is clicked.");
+        if (isValidUrl(url)) {
+          // Here you can handle the URL, for example, attach it to the selected item
+          // @ts-ignore
+          AFRAME.INSPECTOR.selectedEntity.setAttribute('new-tab-link', { href: url });
+        } else {
+          alert("The URL you entered is not valid. Please try again.");
+        };
+      } else {
+        alert("Please select an item in the scene to add a link to.");
+      };
+      newButton.classList.remove("active");
+    });
+    // Add the new button to the toolbar (as first child)
+    toolbar.prepend(newButton);
+  };
+
+  const customizeCentralToolbar = () => {
+    // Get the toolbar element by its ID
+    const toolbar = document.getElementById("transformToolbar");
+    if(toolbar) {
+      // Add a new button for adding a URL link to an item to the toolbar
+      addLinkButtonToToolbar(toolbar);
+    } else {
+      // Inspector hasn't loaded yet
+      setTimeout(() => {
+        customizeCentralToolbar();
+      }, 500);
+    };
+  };
+
   // Edit mode options
   //  Function to toggle whether any Edit Mode option's popup is open
   let openEditModelPopup = false;
@@ -1073,6 +1120,8 @@
     customizeLeftPanel();
     // Customize features on the Right Panel
     customizeRightPanel();
+    // Customize the toolbar (top center)
+    customizeCentralToolbar();
   };
 
   const editButtonOnClick = async () => {


### PR DESCRIPTION
In the Edit mode, the user may now add a link to an item which will be opened in a new tab when the item is clicked.

To test:
In the Edit mode, the central top toolbar should have a new icon for the link (left most icon).
Click it (without selecting an item first) and a popup should appear.
Select an item and click it again. A popup with an input field should appear.
Provide an invalid URL and ensure that an error popup is displayed.
Provide a valid URL and save your changes.
The item should now be clickable and the URL should open in a new tab.

Now other functionality should be affected.