### PR TITLE
Add Exploration mode as stream of spaces

### DIFF
--- a/src/PersonalWebSpace_frontend/components/UserSpace.svelte
+++ b/src/PersonalWebSpace_frontend/components/UserSpace.svelte
@@ -8,6 +8,7 @@
 
   export let space;
   export let entityIdToLinkTo: string = ""; // If Entity Id is provided, Space should include a Link button to that Entity
+  export let spaceIframeHeight: string = "auto";
 
   const spaceURL =
     process.env.NODE_ENV !== "development"
@@ -101,10 +102,8 @@
 </script>
 
 <div class="responsive">
-  <div class="space space-y-1"> 
-    <a target="_blank" rel="noreferrer" href={spaceURL} >
-      <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height="auto" referrerpolicy="no-referrer"></iframe>
-    </a>
+  <div class="space space-y-1">
+    <iframe src={spaceURL} title="Your flaming hot Personal Web Space" width="100%" height={spaceIframeHeight} referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin"></iframe>
     {#if isViewerSpaceOwner() && entityIdToLinkTo !== ""}
       {#if linkCreationInProgress}
         <button disabled class="bg-slate-500 text-white py-2 px-4 rounded font-bold opacity-50 cursor-not-allowed">Linking...</button>

--- a/src/PersonalWebSpace_frontend/pages/ExploreSpaces.svelte
+++ b/src/PersonalWebSpace_frontend/pages/ExploreSpaces.svelte
@@ -1,17 +1,34 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-  import { PersonalWebSpace_backend } from "canisters/PersonalWebSpace_backend";
+  import { onMount, afterUpdate } from "svelte";
   import { store } from "../store";
   
   import Topnav from "../components/Topnav.svelte";
   import Footer from "../components/Footer.svelte";
-  import UserSpaces from "../components/UserSpaces.svelte";
+  import UserSpace from "../components/UserSpace.svelte";
+
+  import { initiateCollapsibles } from "../helpers/space_helpers.js";
 
   import spinner from "../assets/loading.gif"; // TODO: load other assets (e.g. html pages) similarly (see https://vitejs.dev/guide/assets.html: Referenced assets are included as part of the build assets graph, will get hashed file names, and can be processed by plugins for optimization)
 
   const numberOfRandomSpacesToLoad = 3;
   let loading = true;
   let loadedRandomSpaces = [];
+  let currentIndex = 0;
+
+  const nextSpace = async () => {
+    if (currentIndex < loadedRandomSpaces.length - 2) {
+      currentIndex++;
+    } else {
+      currentIndex++;
+      await loadUserSpaces();
+    }
+  };
+
+  const prevSpace = () => {
+    if (currentIndex > 0) {
+      currentIndex--;
+    }
+  };
 
   const loadUserSpaces = async () => {
     let requestPromises = [];
@@ -27,24 +44,32 @@
         randomSpacesIds.push(spaceNFTResponses[j].Ok.id);
       };
     };
-    loadedRandomSpaces = randomSpaces;
+    loadedRandomSpaces = [...loadedRandomSpaces, ...randomSpaces];
     loading = false;
   };
 
   onMount(loadUserSpaces);
+  afterUpdate(initiateCollapsibles);
 </script>
 
 <Topnav />
 
-<section id="spaces" class="py-7 space-y-6 items-center text-center bg-slate-100">
+<section id="spaces" class="py-7 space-y-3 items-center text-center bg-slate-100">
   <h3 class="text-xl font-bold">Explore Web Spaces</h3>
   {#if loading}
     <p id='spacesSubtext'>Searching the Open Internet Metaverse for a few random Spaces to show you...</p>
     <img class="h-12 mx-auto" src={spinner} alt="loading animation" />
   {:else}
-    <p id='spacesSubtext'>These are a few Spaces that OIM Users own:</p>
-    <div id='randomSpaces' class="space-y-4">
-      <UserSpaces spaces={loadedRandomSpaces} />
+    <div id='randomSpaces' class="space-y-1">
+      {#if currentIndex > 0}
+        <button on:click={prevSpace} class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">Previous</button>
+      {:else}
+        <button disabled class="bg-slate-500 text-white py-2 px-4 rounded font-bold opacity-50 cursor-not-allowed">Previous</button>
+      {/if}
+      <button on:click={nextSpace} class="active-app-button bg-slate-500 text-white py-2 px-4 rounded font-semibold">Next</button>
+      {#key currentIndex}
+        <UserSpace space={loadedRandomSpaces[currentIndex]} spaceIframeHeight={"500px"}/>
+      {/key}
     </div>
   {/if}
 </section>


### PR DESCRIPTION
Reworks the Exploration mode (tab Explore) to show one random space at a time and letting the users go back and forth between random spaces via Previous and Next buttons such that they can explore a stream of spaces.

To test:
Go to the Explore tab, a random space should be loaded and displayed.
Make sure that the View button opens the space in another tab and that the See Details button shows more info.
The Previous button should be disabled. 
Click the Next button and the next space should load. You should be able to do this infinitely.
Click the Previous button and the previous space should load. You should be able to do this until you're back on the first space.